### PR TITLE
Fix lint issue and tidy README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,6 @@ lib/ # Supabase client and utilities
 types/ # Shared types (e.g. Supabase schema)
 styles/ # Tailwind + global styles
 
-yaml
-Copy
-Edit
 
 ---
 
@@ -61,26 +58,28 @@ Edit
 git clone https://github.com/YOUR_ORG/chemfetch-client-hub.git
 cd chemfetch-client-hub
 npm install
-Create .env.local with your Supabase details:
+```
 
-env
-Copy
-Edit
+Create a `.env.local` file with your Supabase details:
+
+```env
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+```
+
 Run the dev server:
 
-bash
-Copy
-Edit
+```bash
 npm run dev
+```
+
 🧪 Dev Tips
 Run type checks:
 
-bash
-Copy
-Edit
+```bash
 npx tsc --noEmit
+```
+
 Deploy via Vercel for instant frontend hosting
 
 Supabase schema is managed in the chemfetch-supabase repo
@@ -91,9 +90,6 @@ MIT (or custom license if commercial)
 🙋 Support
 This is part of a private platform. For access, onboarding, or bug reports, please contact the project maintainer.
 
-yaml
-Copy
-Edit
 
 ---
 

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -20,7 +20,7 @@ export interface Database {
         }
       }
     }
-    Views: {}
-    Functions: {}
+    Views: Record<string, never>
+    Functions: Record<string, never>
   }
 }


### PR DESCRIPTION
## Summary
- ensure Supabase type file avoids `{}` which triggers lint error
- clean up README formatting and code snippets

## Testing
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_68877cb2cf60832f8edf361e589e29b6