### PR TITLE
Fix type errors and simplify watch list

### DIFF
--- a/src/app/sds/page.tsx
+++ b/src/app/sds/page.tsx
@@ -2,6 +2,14 @@
 import { redirect } from 'next/navigation'
 import { supabaseServer } from '@/lib/supabase-server'
 
+type WatchListItem = {
+  id: number
+  product: {
+    name: string
+    sds_url: string | null
+  }
+}
+
 export default async function SdsPage() {
   const supabase = supabaseServer()
   const {
@@ -13,6 +21,7 @@ export default async function SdsPage() {
   const { data: watchList } = await supabase
     .from('user_chemical_watch_list')
     .select('id, product(name, sds_url)')
+    .returns<WatchListItem[]>()
 
   return (
     <div className="p-4">
@@ -21,7 +30,7 @@ export default async function SdsPage() {
         {watchList?.map((item) => (
           <li key={item.id}>
             <a
-              href={item.product.sds_url}
+              href={item.product.sds_url ?? '#'}
               target="_blank"
               className="text-blue-600 hover:underline"
             >

--- a/src/app/watchlist/page.tsx
+++ b/src/app/watchlist/page.tsx
@@ -19,10 +19,20 @@ export default function WatchListPage() {
         <ul className="space-y-2">
           {data.map((entry) => (
             <li key={entry.id} className="border p-4 rounded shadow">
-              <p><strong>Product:</strong> {entry.products?.product_name ?? 'Unknown'}</p>
-              <p><strong>Location:</strong> {entry.location}</p>
-              <p><strong>Quantity:</strong> {entry.quantity_on_hand}</p>
-              <p><strong>SDS:</strong> {entry.sds_available ? '✅' : '❌'}</p>
+              <p>
+                <strong>Product:</strong> {entry.products.name}
+              </p>
+              {entry.products.sds_url && (
+                <p>
+                  <a
+                    href={entry.products.sds_url}
+                    target="_blank"
+                    className="text-blue-600 hover:underline"
+                  >
+                    View SDS
+                  </a>
+                </p>
+              )}
             </li>
           ))}
         </ul>

--- a/src/lib/hooks/useWatchList.ts
+++ b/src/lib/hooks/useWatchList.ts
@@ -2,8 +2,17 @@
 import { useEffect, useState } from 'react';
 import { supabaseBrowser } from '@/lib/supabase-browser';
 
+export type WatchListItem = {
+  id: number
+  products: {
+    id: string
+    name: string
+    sds_url: string | null
+  }
+}
+
 export function useWatchList() {
-  const [data, setData] = useState<any[]>([]);
+  const [data, setData] = useState<WatchListItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -13,8 +22,9 @@ export function useWatchList() {
 
       const { data, error } = await supabase
         .from('user_chemical_watch_list')
-        .select('*, products(*)')
-        .order('created_at', { ascending: false });
+        .select('id, products(id, name, sds_url)')
+        .order('added_at', { ascending: false })
+        .returns<WatchListItem[]>();
 
       if (error) setError(error.message);
       else setData(data || []);

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -19,6 +19,22 @@ export interface Database {
           product_id?: string
         }
       }
+      products: {
+        Row: {
+          id: string
+          name: string
+          sds_url: string | null
+        }
+        Insert: {
+          id: string
+          name: string
+          sds_url?: string | null
+        }
+        Update: {
+          name?: string
+          sds_url?: string | null
+        }
+      }
     }
     Views: Record<string, never>
     Functions: Record<string, never>


### PR DESCRIPTION
## Summary
- add missing `products` table definition in Supabase types
- type and cast watchlist fetch for SDS page
- fix null `sds_url` link in SDS page
- type watch list hook and adjust fetch
- simplify watch list page UI

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6888afe0ba3c832f8e1ebead64f8496d