### PR TITLE
Fix cookies warning with Next.js 15

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,7 @@ import { supabaseServer } from '@/lib/supabase-server'
 
 export default async function DashboardPage() {
   // 1. Check session on the server
-  const supabase = supabaseServer()
+  const supabase = await supabaseServer()
   const {
     data: { session },
   } = await supabase.auth.getSession()

--- a/src/app/sds/page.tsx
+++ b/src/app/sds/page.tsx
@@ -11,7 +11,7 @@ type WatchListItem = {
 }
 
 export default async function SdsPage() {
-  const supabase = supabaseServer()
+  const supabase = await supabaseServer()
   const {
     data: { session },
   } = await supabase.auth.getSession()

--- a/src/lib/supabase-server.ts
+++ b/src/lib/supabase-server.ts
@@ -3,14 +3,11 @@ import { cookies } from 'next/headers'
 import { createServerComponentClient } from '@supabase/auth-helpers-nextjs'
 import type { Database } from '@/types/supabase'
 
-// no 'async' here—call cookies() synchronously
-export function supabaseServer() {
-  // call cookies() synchronously; don't await it
-  const cookieStore = cookies()
+// cookies() became async in Next.js 15. Await the call and expose an async helper.
+export async function supabaseServer() {
+  const cookieStore = await cookies()
 
-  // pass a synchronous function returning the cookie store
   return createServerComponentClient<Database>({
-    // return the cookieStore directly; do not make this async
     cookies: () => cookieStore,
   })
 }


### PR DESCRIPTION
## Summary
- update `supabaseServer` helper to await `cookies()`
- adjust page components to use the async helper

## Testing
- `npm run lint`
- `npm run build` *(fails: unable to fetch fonts from fonts.gstatic.com)*

------
https://chatgpt.com/codex/tasks/task_e_6888b5635ba0832f9e667f8a28944912