### PR TITLE
Fix watch list query and login lint error

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -71,13 +71,13 @@ const handleSubmit = async (e: React.FormEvent) => {
         >
           Sign In
         </button>
-        <p className="text-sm text-center">
-          Don't have an account?{' '}
-          <Link href="/register" className="text-blue-600 hover:underline">
-            Register
-          </Link>
-        </p>
-      </form>
-    </div>
-  )
-}
+          <p className="text-sm text-center">
+            Don&apos;t have an account?{' '}
+            <Link href="/register" className="text-blue-600 hover:underline">
+              Register
+            </Link>
+          </p>
+        </form>
+      </div>
+    )
+  }

--- a/src/lib/hooks/useWatchList.ts
+++ b/src/lib/hooks/useWatchList.ts
@@ -23,7 +23,8 @@ export function useWatchList() {
       const { data, error } = await supabase
         .from('user_chemical_watch_list')
         .select('id, product:product_id(id, name, sds_url)')
-        .order('created_at', { ascending: false })
+        // The table uses `added_at` to track insert time
+        .order('added_at', { ascending: false })
         .returns<WatchListItem[]>();
 
       if (error) setError(error.message);


### PR DESCRIPTION
## Summary
- correct watch list query to sort by `added_at`
- escape apostrophe in login page text to satisfy lint

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688da5eb213c832fb63816da3cb2c347